### PR TITLE
fix mixins to client only

### DIFF
--- a/TRLForge/src/main/resources/transliterationlib.forge.mixins.json
+++ b/TRLForge/src/main/resources/transliterationlib.forge.mixins.json
@@ -4,15 +4,14 @@
   "compatibilityLevel": "JAVA_8",
   "refmap": "transliterationlib.forge.refmap.json",
   "mixins": [
+  ],
+  "client":[
     "PlayerSkinProviderMixin",
     "AbstractClientPlayerEntityMixin",
     "DefaultSkinHelperMixin",
     "PlayerEntityMixin",
     "PlayerEntityModelMixin",
     "HeldItemFeatureRendererMixin"
-  ],
-  "client":[
-    
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
mixin loading is set to client only now to avoid loading while running server and crashing

note: we use this mod as a dependency for our own mod which is meant to run on both client and server